### PR TITLE
Allow Ctrl+Return to run code

### DIFF
--- a/game.js
+++ b/game.js
@@ -21,6 +21,12 @@ var game = {
 
     $('#code').on('keydown', function(e) {
       if (e.keyCode === 13) {
+        if (e.ctrlKey || e.metaKey) {
+          e.preventDefault();
+          $('#submit').click();
+          return
+        }
+
         var max = $(this).data('lines');
         var code = $(this).val();
         var trim = code.trim();


### PR DESCRIPTION
Allow pressing Ctrl and the Return key at any point to run the code in the editor instead of having to click submit or use up all lines and press Return.
