### PR TITLE
Fix French translation and German diacritic entities

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
       </div>
       <div id="credits">
         <p>Flexbox Froggy is created by <a href="http://thomaspark.co">Thomas Park</a> • <a href="http://github.com/thomaspark/flexboxfroggy/">GitHub</a> • <a href="https://twitter.com/thomashpark">Twitter</a></p>
-        <p><a href="lang/de/">Deutsch</a> • <a href="lang/pt-br/">Portuguese</a> • <a href="lang/fr/">French</a>
+        <p><a href="lang/de/">Deutsch</a> • <a href="lang/pt-br/">Portuguese</a> • <a href="lang/fr/">Français</a>
       </div>
     </section>
     <section id="view">

--- a/js/messages.js
+++ b/js/messages.js
@@ -1,13 +1,13 @@
 var messages = {
   warningReset: {
     'en': 'Are you sure you want to reset the game?\n\nYour saved progress will be lost and you\'ll be sent to the start of the game.',
-    'de': 'Bist su sicher, dass du das Spiel zur&uuml;cksetzen m&ouml;chtest?\n\nDein gespeicherter Fortschritt geht dabei verloren und du musst das Spiel von neuem starten.',
+    'de': 'Bist su sicher, dass du das Spiel zurücksetzen möchtest?\n\nDein gespeicherter Fortschritt geht dabei verloren und du musst das Spiel von neuem starten.',
     'fr': 'Êtes-vous certain de vouloir réinitialiser la partie?\n\nVotre progrès sauvegardé sera perdu et vous recommencerez au début du jeu.',
     'pt-br': 'Você tem certeza que quer reinicializar o jogo?\n\nSeu progresso salvo será perdido e você voltará ao começo do jogo.'
   },
   labelReset: {
     'en': 'Reset',
-    'de': 'Zur&uuml;cksetzen',
+    'de': 'Zurücksetzen',
     'fr': 'Réinitialiser',
     'pt-br': 'Reinicializar'
   }


### PR DESCRIPTION
Changes:
* Change French to Français just like German was changed to Deutsch in #28. (I guess Portuguese should be changed to *português* according to Wikipedia but I don't speak the language so I didn't touch it.)
* Change encoded entities in the German translation because they showed up as-is (`jQuery.text` function + JavaScript `confirm` function don't use HTML)

I know you closed #24 (:+1: to the idea, though I didn't think localizing was that painful, but structure can't hurt anyone) so maybe you're currently changing the whole i18n structure but these commits should still trivial to implement in the new structure.

Thanks for the quick merge earlier! If you add anything and need new french translations, just tag me and I'll try to take care of it.