### PR TITLE
Consider: Don't require delimiting semicolons

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -255,7 +255,7 @@ var game = {
 
   applyStyles: function() {
     var level = levels[game.level];
-    var code = $('#code').val();
+    var code = $('#code').val().replace(/\n/g, ';');
     var selector = level.selector || '';
     $('#pond ' +  selector).attr('style', code);
     game.saveAnswer();


### PR DESCRIPTION
Thank you for making this game! Incredibly well-executed.

I'm aware of issues #15 (_Indication of invalid style_) and #18 (_Require semicolons_).

This might be a bit contentious, but I feel requiring users to delimit lines with semicolons only detracts from the purpose of the game—to have fun learning flexbox.
