### PR TITLE
Make line-numbers class fill container height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -149,7 +149,6 @@ pre {
   text-align: right;
   background-color: #999;
   color: #D5D5D5;
-
 }
 
 #code {

--- a/css/style.css
+++ b/css/style.css
@@ -144,10 +144,12 @@ pre {
   position: absolute;
   top: 0;
   left: 0;
+  height: 100%;
   padding: 10px 6px;
   text-align: right;
   background-color: #999;
   color: #D5D5D5;
+
 }
 
 #code {


### PR DESCRIPTION
Fixes #112 

@thomaspark here is a quick PR to fill the container height of the `line-numbers` class.