### PR TITLE
for some reason .tooltip was set to 0 top padding. Fixed that

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -73,7 +73,7 @@ a:hover {
   position: absolute;
   display: inline-block;
   max-width: 225px;
-  padding: 0 1em 1em;
+  padding: 1em 1em;
   background-color: #2c3e50;
   border-radius: 4px;
   font-size: 12px;


### PR DESCRIPTION
Created a separate pull request as I don't think it was related to the easy/hard mode PR