### PR TITLE
Fix "next" button not translating after load

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -46,7 +46,7 @@ var game = {
         return;
       }
 
-      $(this).removeClass();
+      $(this).removeClass('animated animation');
       $('.frog').addClass('animated bounceOutUp');
       $('.arrow, #next').addClass('disabled');
 
@@ -88,7 +88,7 @@ var game = {
     }).on('input', game.debounce(game.check, 500))
     .on('input', function() {
       game.changed = true;
-      $('#next').removeClass().addClass('disabled');
+      $('#next').removeClass('animated animation').addClass('disabled');
     });
 
     $('#editor').on('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
@@ -243,7 +243,7 @@ var game = {
     $('#level-counter .current').text(this.level + 1);
     $('#before').text(level.before);
     $('#after').text(level.after);
-    $('#next').removeClass().addClass('disabled');
+    $('#next').removeClass('animated animation').addClass('disabled');
 
     var instructions = level.instructions[game.language] || level.instructions.en;
     $('#instructions').html(instructions);
@@ -377,7 +377,7 @@ var game = {
       }
 
       $('[data-level=' + game.level + ']').addClass('solved');
-      $('#next').removeClass().addClass('animated animation');
+      $('#next').removeClass('disabled').addClass('animated animation');
     } else {
       ga('send', {
         hitType: 'event',


### PR DESCRIPTION
This PR is mirroring the changes from https://github.com/thomaspark/gridgarden/pull/116 to here.

For this repo, the issue was introduced in https://github.com/thomaspark/flexboxfroggy/commit/06e5b86fb2d63935406858487b45da5c6fa446ac

Text from original PR:

> First of all, thank you @thomaspark and contributors for the wonderful games 👏
> 
> The changes in 2d042ca caused the "next" button to not be translated if you change the language after the page initially loads.
> 
> The page loaded in Dutch for me, but I prefer to play in English, which is how I noticed.
> 
> This PR changes the removeClass() calls without arguments (which remove all classes), to calls with arguments to only remove the required classes.