### PR TITLE
Fix #193. Add short answers. Improve auto clicking of the Next button.

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -69,20 +69,25 @@ var game = {
           return;
         }
 
-        var max = $(this).data('lines');
+        var max = $(this).data('max');
+        var min = $(this).data('min');
         var code = $(this).val();
         var trim = code.trim();
         var codeLength = code.split('\n').length;
         var trimLength = trim.split('\n').length;
 
-        if (codeLength >= max) {
+        if (codeLength >= min) {
 
-          if (codeLength === trimLength) {
+          if (! $('#next').hasClass('disabled')) {
             e.preventDefault();
             $('#next').click();
-          } else {
-            $('#code').focus().val('').val(trim);
+            return;
           }
+
+          if (trimLength >= max) {
+            e.preventDefault();
+          }
+          $('#code').focus().val('').val(trim);
         }
       }
     }).on('input', game.debounce(game.check, 500))
@@ -125,7 +130,7 @@ var game = {
       var $instructions = $('#instructions');
       var height = $instructions.height();
       $instructions.css('height', height);
-      
+
       if (game.difficulty == 'hard' || game.difficulty == 'medium') {
         $instructions.slideUp();
       } else {
@@ -264,7 +269,8 @@ var game = {
     this.loadDocs();
 
     var lines = Object.keys(level.style).length;
-    $('#code').height(20 * lines).data("lines", lines);
+    var min = level.styleShort ? Object.keys(level.styleShort).length : lines;
+    $('#code').height(20 * lines).data('max', lines).data('min', min);
 
     var string = level.board;
     var markup = '';

--- a/js/levels.js
+++ b/js/levels.js
@@ -915,6 +915,7 @@ var levels = [
     },
     board: 'gggggrrrrryyyyy',
     style: {'flex-direction': 'column', 'flex-wrap': 'wrap'},
+    styleShort: {'flex-flow': 'column wrap'},
     before: "#pond {\n  display: flex;\n",
     after: "}"
   },
@@ -1158,6 +1159,7 @@ var levels = [
     },
     board: 'rggggyy',
     style: {'flex-direction': 'column-reverse', 'flex-wrap': 'wrap-reverse', 'align-content': 'space-between', 'justify-content': 'center'},
+    styleShort: {'flex-flow': 'column-reverse wrap-reverse', 'align-content': 'space-between', 'justify-content': 'center'},
     before: "#pond {\n  display: flex;\n",
     after: "}"
   }


### PR DESCRIPTION
Levels 19 and 24 have two solutions - with a shorthand property [`flex-flow`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-flow) and without it. When the user types a short solution, the <kbd>Next</kbd> button becomes available, but pressing <kbd>Enter</kbd> in the code area doesn't automatically activate this button.

To fix this, I've made the following improvements:

1) Add short alternatives for answers in the `level.js` file with the `styleShort` key.
2) Calculate the two data values `min` and `max` for the short and long versions of the answer (instead of the single parameter `lines`).
3) Check if the <kbd>Next</kbd> button is enabled to automatically click it (instead of comparing the length of the code).
4) Check if the code is longer than the short answer to start additional checks.
5) Check if the truncated code is longer than the long answer to prevent new blank lines from appearing.

I've tested the new behavior on my localhost.
Would be glad for your feedback.