### PR TITLE
Feature to write CSS property when click property value in tooltip

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -114,6 +114,10 @@ a:hover {
   border-bottom: 12px solid #2c3e50;
 }
 
+#instructions .tooltip code {
+  cursor: pointer;
+}
+
 #share {
   display: none;
   margin-bottom: 3em;
@@ -348,18 +352,18 @@ pre {
 
 .triangle {
   display: inline-block;
-  width: 0; 
-  height: 0; 
+  width: 0;
+  height: 0;
   border-top: 7px solid transparent;
-  border-bottom: 7px solid transparent; 
+  border-bottom: 7px solid transparent;
 }
 
 .left .triangle {
-  border-right: 11px solid rgba(255, 255, 255, 0.7);; 
+  border-right: 11px solid rgba(255, 255, 255, 0.7);;
 }
 
 .right .triangle {
-  border-left: 11px solid rgba(255, 255, 255, 0.7);; 
+  border-left: 11px solid rgba(255, 255, 255, 0.7);;
 }
 
 button {

--- a/css/style.css
+++ b/css/style.css
@@ -102,17 +102,6 @@ a:hover {
   z-index: 60;
 }
 
-#instructions .tooltip:before{
-  content: '';
-  position: absolute;
-  display: inline-block;
-  top: -12px;
-  left: 0px;
-  width: 100%;
-  height: 120%;
-  z-index: -1;
-}
-
 .tooltip:after {
   content: '';
   position: absolute;

--- a/css/style.css
+++ b/css/style.css
@@ -102,6 +102,17 @@ a:hover {
   z-index: 60;
 }
 
+#instructions .tooltip:before{
+  content: '';
+  position: absolute;
+  display: inline-block;
+  top: -12px;
+  left: 0px;
+  width: 100%;
+  height: 120%;
+  z-index: -1;
+}
+
 .tooltip:after {
   content: '';
   position: absolute;

--- a/js/game.js
+++ b/js/game.js
@@ -111,7 +111,7 @@ var game = {
 
     $('#labelSettings').on('click', function() {
       $('#levelsWrapper').hide();
-      $('#settings .tooltip').show();
+      $('#settings .tooltip').toggle();
     })
 
     $('#language').on('change', function() {
@@ -230,7 +230,7 @@ var game = {
 
     $('#level-indicator').on('click', function() {
       $('#settings .tooltip').hide();
-      $('#levelsWrapper').show();
+      $('#levelsWrapper').toggle();
     });
 
     $('.arrow.left').on('click', function() {

--- a/js/game.js
+++ b/js/game.js
@@ -7,6 +7,7 @@ var game = {
   solved: (localStorage.solved && JSON.parse(localStorage.solved)) || [],
   user: localStorage.user || '',
   changed: false,
+  clickedCode: null,
 
   start: function() {
     // navigator.language can include '-'
@@ -163,6 +164,7 @@ var game = {
 
     $('body').on('click', function() {
       $('.tooltip').hide();
+      clickedCode = null;
     });
 
     $('.tooltip, .toggle, #level-indicator').on('click', function(e) {
@@ -329,33 +331,34 @@ var game = {
 
       if (text in docs) {
         code.addClass('help');
-        code.on('mouseenter', function(e) {
-          if($('#instructions .tooltip').length !== 0) {
+        code.on('click', function(e) {
+          e.stopPropagation();
+
+          // If click same code when tooltip already displayed, just remove current tooltip.
+          if ($('#instructions .tooltip').length !== 0 && clickedCode === code){
             $('#instructions .tooltip').remove();
+            return;
           }
-          if ($('#instructions .tooltip').length === 0) {
-            var html = docs[text][game.language] || docs[text].en;
-            var tooltipX = code.offset().left;
-            var tooltipY = code.offset().top + code.height() + 13;
-            $('<div class="tooltip"></div>').html(html).css({
-              top: tooltipY,
-              left: tooltipX
-            }).appendTo($('#instructions'));
 
-            $('#instructions .tooltip code').on('click', function(event) {
-              var pName = text
-              var pValue = event.target.textContent.split(' ')[0];
-              pValue = pValue === "<integer>" ? 0 : pValue;
-              game.writeCSS(pName, pValue)
+          $('#instructions .tooltip').remove();
+          var html = docs[text][game.language] || docs[text].en;
+          var tooltipX = code.offset().left;
+          var tooltipY = code.offset().top + code.height() + 13;
+          $('<div class="tooltip"></div>').html(html).css({
+            top: tooltipY,
+            left: tooltipX
+          }).appendTo($('#instructions'));
 
-              game.check();
-            });
-            $("#instructions .tooltip code").css('cursor', 'pointer');
-          }
-        }).on('mouseleave', function() {
-          $('#instructions .tooltip').on('mouseleave', function() {
-            $('#tooltip').remove();
+          $('#instructions .tooltip code').on('click', function(event) {
+            var pName = text
+            var pValue = event.target.textContent.split(' ')[0];
+            pValue = pValue === "<integer>" ? 0 : pValue;
+            game.writeCSS(pName, pValue)
+
+            game.check();
           });
+          $("#instructions .tooltip code").css('cursor', 'pointer');
+          clickedCode = code;
         });
       }
     });

--- a/js/game.js
+++ b/js/game.js
@@ -328,7 +328,6 @@ var game = {
       var text = code.text();
 
       if (text in docs) {
-        var flag = false; // to check click or not
         code.addClass('help');
         code.on('mouseenter', function(e) {
           if($('#instructions .tooltip').length !== 0) {
@@ -350,7 +349,6 @@ var game = {
               game.writeCSS(pName, pValue)
 
               game.check();
-              flag = true;
             });
             $("code").css('cursor', 'pointer');
           }

--- a/js/game.js
+++ b/js/game.js
@@ -129,7 +129,7 @@ var game = {
       $instructions.css('height', height);
 
       var $markers = $('.level-marker');
-      
+
       if (game.difficulty == 'hard' || game.difficulty == 'medium') {
         $instructions.slideUp();
 
@@ -509,6 +509,9 @@ var game = {
     var keywords = Object.keys(docs);
     var content = '';
     var filled = false;
+
+    // Do nothing when click property name inside Tooltip
+    if (keywords.includes(pValue)) return;
 
     tokens.forEach(function (token, i){
       var trimmedToken = token.trim();

--- a/js/game.js
+++ b/js/game.js
@@ -342,13 +342,14 @@ var game = {
               top: tooltipY,
               left: tooltipX
             }).appendTo($('#instructions'));
-            $("#instructions .tooltip code").click(function(event) {
-              var content = event.target.textContent.split(" ")[0];
-              if(content == "<integer>"){
-                content = 0;
-              }
-              var ordinary = $('#code').val().concat(content);
-              $('#code').val(ordinary);
+
+            $('#instructions .tooltip code').on('click', function(event) {
+              var pName = text
+              var pValue = event.target.textContent.split(' ')[0];
+              pValue = pValue === "<integer>" ? 0 : pValue;
+              game.writeCSS(pName, pValue)
+
+              game.check();
               flag = true;
             });
             $("code").css('cursor', 'pointer');
@@ -484,6 +485,39 @@ var game = {
       timeout = setTimeout(later, wait);
       if (callNow) func.apply(context, args);
     };
+  },
+
+  writeCSS: function(pName, pValue){
+    var tokens = $('#code').val().trim().split(/[\s:;]+/);
+    var keywords = ['justify-content', 'align-items', 'flex-direction', // TODO: Is there any way not to add new keywords?
+      'order', 'align-self', 'flex-wrap', 'flex-flow', 'align-content'];
+    var content = '';
+    var filled = false;
+
+    tokens.forEach(function (token, i){
+      if (!keywords.includes(token)){
+        return;
+      }
+
+      var append = content !== '' ? '\n' : '';
+      if (token === pName && !filled)
+      {
+        filled = true;
+        append += token + ': ' + pValue + ';';
+      }
+      else if (i + 1 < tokens.length){
+        append += token + ': ' + tokens.at(i + 1) + ';';
+      }
+
+      content += append;
+    });
+
+    if (!filled){
+      content += content !== '' ? '\n' : '';
+      content += pName + ': ' + pValue + ';';
+    }
+
+    $('#code').val(content);
   }
 };
 

--- a/js/game.js
+++ b/js/game.js
@@ -423,6 +423,9 @@ var game = {
         eventAction: 'incorrect',
         eventLabel: $('#code').val()
       });
+
+      game.changed = true;
+      $('#next').removeClass('animated animation').addClass('disabled');
     }
   },
 

--- a/js/game.js
+++ b/js/game.js
@@ -111,7 +111,7 @@ var game = {
 
     $('#labelSettings').on('click', function() {
       $('#levelsWrapper').hide();
-      $('#settings .tooltip').toggle();
+      $('#settings .tooltip').show();
     })
 
     $('#language').on('change', function() {
@@ -162,7 +162,7 @@ var game = {
     });
 
     $('body').on('click', function() {
-      $('.tooltip').remove();
+      $('.tooltip').hide();
     });
 
     $('.tooltip, .toggle, #level-indicator').on('click', function(e) {
@@ -230,7 +230,7 @@ var game = {
 
     $('#level-indicator').on('click', function() {
       $('#settings .tooltip').hide();
-      $('#levelsWrapper').toggle();
+      $('#levelsWrapper').show();
     });
 
     $('.arrow.left').on('click', function() {

--- a/js/game.js
+++ b/js/game.js
@@ -370,7 +370,6 @@ var game = {
 
             game.check();
           });
-          $("#instructions .tooltip code").css('cursor', 'pointer');
           clickedCode = code;
         });
       }

--- a/js/game.js
+++ b/js/game.js
@@ -521,6 +521,7 @@ var game = {
     }
 
     $('#code').val(content);
+    $('#code').focus();
   }
 };
 

--- a/js/game.js
+++ b/js/game.js
@@ -343,7 +343,8 @@ var game = {
               left: tooltipX
             }).appendTo($('#instructions'));
             $("#instructions .tooltip code").click(function(event) {
-              var ordinary = $('#code').val().concat(event.target.textContent);
+              var clickedCode = event.target.textContent;
+              var ordinary = $('#code').val().concat(clickedCode.split(" ")[0]);
               $('#code').val(ordinary);
               flag = true;
             });

--- a/js/game.js
+++ b/js/game.js
@@ -343,8 +343,11 @@ var game = {
               left: tooltipX
             }).appendTo($('#instructions'));
             $("#instructions .tooltip code").click(function(event) {
-              var clickedCode = event.target.textContent;
-              var ordinary = $('#code').val().concat(clickedCode.split(" ")[0]);
+              var content = event.target.textContent.split(" ")[0];
+              if(content == "<integer>"){
+                content = 0;
+              }
+              var ordinary = $('#code').val().concat(content);
               $('#code').val(ordinary);
               flag = true;
             });

--- a/js/game.js
+++ b/js/game.js
@@ -336,7 +336,8 @@ var game = {
             var tooltipY = code.offset().top + code.height() + 13;
             $('<div class="tooltip"></div>').html(html).css({top: tooltipY, left: tooltipX}).appendTo($('#instructions'));
           }
-        }).on('mouseleave', function() {
+        });
+        code.on('mouseleave', function() {
           $('#instructions .tooltip').remove();
         });
       }

--- a/js/game.js
+++ b/js/game.js
@@ -350,7 +350,7 @@ var game = {
 
               game.check();
             });
-            $("code").css('cursor', 'pointer');
+            $("#instructions .tooltip code").css('cursor', 'pointer');
           }
         }).on('mouseleave', function() {
           $('#instructions .tooltip').on('mouseleave', function() {

--- a/js/game.js
+++ b/js/game.js
@@ -113,6 +113,7 @@ var game = {
     $('#labelSettings').on('click', function() {
       $('#levelsWrapper').hide();
       $('#settings .tooltip').toggle();
+      $('#instructions .tooltip').remove();
     })
 
     $('#language').on('change', function() {
@@ -233,6 +234,7 @@ var game = {
     $('#level-indicator').on('click', function() {
       $('#settings .tooltip').hide();
       $('#levelsWrapper').toggle();
+      $('#instructions .tooltip').remove();
     });
 
     $('.arrow.left').on('click', function() {
@@ -340,6 +342,8 @@ var game = {
             return;
           }
 
+          $('#levelsWrapper').hide();
+          $('#settings .tooltip').hide();
           $('#instructions .tooltip').remove();
           var html = docs[text][game.language] || docs[text].en;
           var tooltipX = code.offset().left;

--- a/js/game.js
+++ b/js/game.js
@@ -349,8 +349,7 @@ var game = {
             });
             $("code").css('cursor', 'pointer');
           }
-        });
-        code.on('mouseleave', function() {
+        }).on('mouseleave', function() {
           $('#instructions .tooltip').on('mouseleave', function() {
             $('#tooltip').remove();
           });

--- a/js/game.js
+++ b/js/game.js
@@ -328,17 +328,30 @@ var game = {
       var text = code.text();
 
       if (text in docs) {
+        var flag = false; // to check click or not
         code.addClass('help');
         code.on('mouseenter', function(e) {
           if ($('#instructions .tooltip').length === 0) {
             var html = docs[text][game.language] || docs[text].en;
             var tooltipX = code.offset().left;
             var tooltipY = code.offset().top + code.height() + 13;
-            $('<div class="tooltip"></div>').html(html).css({top: tooltipY, left: tooltipX}).appendTo($('#instructions'));
+            $('<div class="tooltip"></div>').html(html).css({
+              top: tooltipY,
+              left: tooltipX
+            }).appendTo($('#instructions'));
+            $("#instructions .tooltip code").click(function(event) {
+              var ordinary = $('#code').val().concat(event.target.textContent);
+              $('#code').val(ordinary);
+              flag = true;
+            });
+            $("code").css('cursor', 'pointer');
           }
         });
         code.on('mouseleave', function() {
-          $('#instructions .tooltip').remove();
+          if (flag){
+            flag = false;
+            $('#instructions .tooltip').remove();
+          }
         });
       }
     });

--- a/js/game.js
+++ b/js/game.js
@@ -506,7 +506,7 @@ var game = {
         append += token + ': ' + pValue + ';';
       }
       else if (i + 1 < tokens.length){
-        append += token + ': ' + tokens.at(i + 1) + ';';
+        append += token + ': ' + tokens[i + 1] + ';';
       }
 
       content += append;

--- a/js/game.js
+++ b/js/game.js
@@ -490,8 +490,7 @@ var game = {
 
   writeCSS: function(pName, pValue){
     var tokens = $('#code').val().trim().split(/[\s:;]+/);
-    var keywords = ['justify-content', 'align-items', 'flex-direction', // TODO: Is there any way not to add new keywords?
-      'order', 'align-self', 'flex-wrap', 'flex-flow', 'align-content'];
+    var keywords = Object.keys(docs);
     var content = '';
     var filled = false;
 

--- a/js/game.js
+++ b/js/game.js
@@ -162,7 +162,7 @@ var game = {
     });
 
     $('body').on('click', function() {
-      $('.tooltip').hide();
+      $('.tooltip').remove();
     });
 
     $('.tooltip, .toggle, #level-indicator').on('click', function(e) {
@@ -331,6 +331,9 @@ var game = {
         var flag = false; // to check click or not
         code.addClass('help');
         code.on('mouseenter', function(e) {
+          if($('#instructions .tooltip').length !== 0) {
+            $('#instructions .tooltip').remove();
+          }
           if ($('#instructions .tooltip').length === 0) {
             var html = docs[text][game.language] || docs[text].en;
             var tooltipX = code.offset().left;
@@ -348,10 +351,9 @@ var game = {
           }
         });
         code.on('mouseleave', function() {
-          if (flag){
-            flag = false;
-            $('#instructions .tooltip').remove();
-          }
+          $('#instructions .tooltip').on('mouseleave', function() {
+            $('#tooltip').remove();
+          });
         });
       }
     });

--- a/js/game.js
+++ b/js/game.js
@@ -505,24 +505,26 @@ var game = {
   },
 
   writeCSS: function(pName, pValue){
-    var tokens = $('#code').val().trim().split(/[\s:;]+/);
+    var tokens = $('#code').val().trim().split(/[\n:;]+/).filter(i => i);
     var keywords = Object.keys(docs);
     var content = '';
     var filled = false;
 
     tokens.forEach(function (token, i){
-      if (!keywords.includes(token)){
+      var trimmedToken = token.trim();
+      if (!keywords.includes(trimmedToken)){
         return;
       }
 
       var append = content !== '' ? '\n' : '';
-      if (token === pName && !filled)
+      if (trimmedToken === pName && !filled)
       {
         filled = true;
-        append += token + ': ' + pValue + ';';
+        append += trimmedToken + ': ' + pValue + ';';
       }
       else if (i + 1 < tokens.length){
-        append += token + ': ' + tokens[i + 1] + ';';
+        var val = !keywords.includes(tokens[i + 1].trim()) ? tokens[i + 1].trim() : ''; // TODO: Maybe prop value validiation required
+        append += trimmedToken + ': ' + val + ';';
       }
 
       content += append;

--- a/js/game.js
+++ b/js/game.js
@@ -353,10 +353,19 @@ var game = {
             left: tooltipX
           }).appendTo($('#instructions'));
 
+          var getDefaultPropVal = (pValue) => {
+            if (pValue == '<integer>')
+              return '0'
+            else if (pValue == '<flex-direction>')
+              return 'row nowrap'
+
+            return pValue;
+          }
+
           $('#instructions .tooltip code').on('click', function(event) {
             var pName = text
             var pValue = event.target.textContent.split(' ')[0];
-            pValue = pValue === "<integer>" ? 0 : pValue;
+            pValue = getDefaultPropVal(pValue);
             game.writeCSS(pName, pValue)
 
             game.check();


### PR DESCRIPTION
Based on the idea presented in #131, my team created feature that writing CSS property when click tooltip value item!
If you look at the image below, you can intuitively understand it.

![Animation](https://user-images.githubusercontent.com/33592844/143492935-d756226e-6471-4392-8a8d-95249e603343.gif)

And there were additional code changes as follows.
- Disabled `next` button in case of incorrect answer when calling `game.check`. Because `game.check` was called every time the css property was clicked.
- Added cover behind tooltip. This is to prevent other tooltip from appearing when clicking on the property value in tooltip.

I'll be waiting for  your review and approval.
Thank you!


