### PR TITLE
Fix tooltip position on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,7 +40,6 @@ body {
 #sidebar {
   width: 50%;
   min-width: 300px;
-  position: relative;
   padding: 2em;
   background-color: #43A047;
   font-size: 15px;


### PR DESCRIPTION
On small devices there's incorrect position of `.tooltip` relative to `code.help` elements. This PR fixes it by removing unnecessary relative position of `#sidebar`.

![1112222](https://github.com/thomaspark/flexboxfroggy/assets/4366033/0fa6592a-3c82-4676-bfb5-8ca4a123a3d7)

The position is calculated incorrectly because pond (`#view`) is placed above sidebar with instructions thanks to this styles:
https://github.com/thomaspark/flexboxfroggy/blob/f586e2d5a6e1a94d0831f146fe7b6c4724faabe2/css/style.css#L595-L597

And in here position for `.tooltip` depends on `.offset()` method that gives coordinates relative to the whole document ([api.jquery.com/offset](https://api.jquery.com/offset/)).
https://github.com/thomaspark/flexboxfroggy/blob/f586e2d5a6e1a94d0831f146fe7b6c4724faabe2/js/game.js#L352-L353

I doublechecked in style.css if some other element depends on `#sidebar` having relative position. There seem to be no such element.