### PR TITLE
Removes audio play

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -586,7 +586,7 @@ button:not(.disabled):hover {
 ::view-transition-old(--frog14),
 ::view-transition-new(--frog14),
 ::view-transition-old(--frog15),
-::view-transition-new(--frog15), {
+::view-transition-new(--frog15) {
   height: 100%;
 }
 

--- a/js/game.js
+++ b/js/game.js
@@ -432,6 +432,7 @@ var game = {
         correct = false;
       }
     });
+    
     if (correct) {
       code.addClass('correct');
 

--- a/js/game.js
+++ b/js/game.js
@@ -432,7 +432,7 @@ var game = {
         correct = false;
       }
     });
-    
+
     if (correct) {
       code.addClass('correct');
 

--- a/js/game.js
+++ b/js/game.js
@@ -432,12 +432,7 @@ var game = {
         correct = false;
       }
     });
-
     if (correct) {
-      if (!code.hasClass('correct')) {
-        game.audio.correct.play();
-      }
-
       code.addClass('correct');
 
       if (game.solved.indexOf(level.name) === -1) {


### PR DESCRIPTION
Addresses #288 

Commit f1cb51a54aca964429d176d0a9602ee09f0c82fb introduced the following code which breaks since `game.audio` is undefined.

      if (!code.hasClass('correct')) {
        game.audio.correct.play();
      }

This removes the above block. 

I removed it because I didn't see an audio file or any other reference for `game.audio` so I'm assuming it is a feature still in development that got merged early.